### PR TITLE
(fix) ws_close emits wrong ws id for ws2:close and notifyPlugins

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 1.1.3
+- fix: ws_close emits wrong ws id for ws2:close and notifyPlugins
+
 # 1.1.2
 - docs: create/update
 - fix: default channel limit in Manager constructor

--- a/lib/manager/events/ws_close.js
+++ b/lib/manager/events/ws_close.js
@@ -17,8 +17,8 @@ module.exports = (m, wsID) => {
     return
   }
 
-  m.notifyPlugins('ws2', 'ws', 'close', { wsID })
-  m.emit('ws2:close', { wsID })
+  m.notifyPlugins('ws2', 'ws', 'close', { id: wsID })
+  m.emit('ws2:close', { id: wsID })
 
   if (!ws.managedClose) {
     debug('removing connection (%d)', wsID)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-core",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Core Bitfinex Node API",
   "engines": {
     "node": ">=7"

--- a/test/lib/manager/events/ws_close.js
+++ b/test/lib/manager/events/ws_close.js
@@ -1,0 +1,30 @@
+/* eslint-env mocha */
+"use strict";
+
+const assert = require("assert");
+const wsClose = require("manager/events/ws_close");
+
+describe("manager:events:ws_close", () => {
+  it("emits selected ws id when ws found in wsPool", () => {
+    const wsId = 1000;
+    const manager = {
+      getWS: () => {},
+      notifyPlugins: (arg1, arg2, arg3, payload) => {
+        assert.strictEqual(payload.id === wsId);
+      },
+      emit: (eventName, payload) => assert.strictEqual(payload.id, wsId)
+    };
+
+    wsClose(manager, manager.id);
+  });
+
+  it("returns when ws not found in wsPool", () => {
+    const manager = {
+      getWS: () => void 0,
+      emit: () => assert.fail(),
+    };
+
+    const wsCloseReturnValue = wsClose(manager, manager.id);
+    assert.strictEqual(wsCloseReturnValue, undefined);
+  });
+});

--- a/test/lib/manager/events/ws_close.js
+++ b/test/lib/manager/events/ws_close.js
@@ -1,30 +1,30 @@
 /* eslint-env mocha */
-"use strict";
+'use strict'
 
-const assert = require("assert");
-const wsClose = require("manager/events/ws_close");
+const assert = require('assert')
+const wsClose = require('manager/events/ws_close')
 
-describe("manager:events:ws_close", () => {
-  it("emits selected ws id when ws found in wsPool", () => {
-    const wsId = 1000;
+describe('manager:events:ws_close', () => {
+  it('emits selected ws id when ws found in wsPool', () => {
+    const wsId = 1000
     const manager = {
       getWS: () => {},
       notifyPlugins: (arg1, arg2, arg3, payload) => {
-        assert.strictEqual(payload.id === wsId);
+        assert.strictEqual(payload.id === wsId)
       },
       emit: (eventName, payload) => assert.strictEqual(payload.id, wsId)
-    };
+    }
 
-    wsClose(manager, manager.id);
-  });
+    wsClose(manager, manager.id)
+  })
 
-  it("returns when ws not found in wsPool", () => {
+  it('returns when ws not found in wsPool', () => {
     const manager = {
-      getWS: () => void 0,
-      emit: () => assert.fail(),
-    };
+      getWS: () => undefined,
+      emit: () => assert.fail()
+    }
 
-    const wsCloseReturnValue = wsClose(manager, manager.id);
-    assert.strictEqual(wsCloseReturnValue, undefined);
-  });
-});
+    const wsCloseReturnValue = wsClose(manager, manager.id)
+    assert.strictEqual(wsCloseReturnValue, undefined)
+  })
+})


### PR DESCRIPTION
### Description:
https://github.com/bitfinexcom/bfx-api-node-core/issues/6

### Breaking changes:
- []

### New features:
- []

### Fixes:
- [x]

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [x] Tests added or updated
- [ ] Documentation updated
