### PR TITLE
Fix: Increase max ws2 event listener count 1.1.5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 1.1.5
+- fix: increase max ws2 event listener count
+
 # 1.1.4
 - feature: add reconnectAllSockets() to Manager
 - fix: close prev socket if open in ws2 reopen() func

--- a/lib/ws2/open.js
+++ b/lib/ws2/open.js
@@ -20,6 +20,8 @@ const open = (url = WS_URL, agent) => {
   const ws = new WebSocket(url, { agent })
   const ev = new EventEmitter()
 
+  ev.setMaxListeners(1000)
+
   bindEV({ ws, ev })
 
   return { ws, ev }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-core",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Core Bitfinex Node API",
   "engines": {
     "node": ">=7"


### PR DESCRIPTION
### Description:
Increases the max `ev` listener count to 1000 (ws2)

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
