### PR TITLE
Fix: Return state from ws2 sub/unsub 1.1.6

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+# 1.1.6
+- fix: return state from ws2 subscribe()
+- fix: return state from ws2 unsubscribe()
+- fix: add missing utf-8-validate dep
+
 # 1.1.5
 - fix: increase max ws2 event listener count
 

--- a/lib/ws2/subscribe.js
+++ b/lib/ws2/subscribe.js
@@ -9,6 +9,7 @@ const send = require('./send')
  * @param {Object} state
  * @param {string} channel - channel type, i.e. 'trades'
  * @param {Object} payload - channel filter, i.e. { symbol: '...' }
+ * @returns {Object} state - original ref
  */
 const subscribe = (state = {}, channel, payload = {}) => {
   debug('subscribing to %s: %j', channel, payload)
@@ -20,6 +21,8 @@ const subscribe = (state = {}, channel, payload = {}) => {
   })
 
   state.pendingSubscriptions.push([channel, payload])
+
+  return state
 }
 
 module.exports = subscribe

--- a/lib/ws2/unsubscribe.js
+++ b/lib/ws2/unsubscribe.js
@@ -9,6 +9,7 @@ const send = require('./send')
  *
  * @param {Object} state
  * @param {string|number} chanId - ID of channel to unsubscribe from
+ * @return {Object} state - original ref
  */
 const unsubscribe = (state = {}, chanId) => {
   debug('unsubscribing from %d', chanId)
@@ -19,6 +20,8 @@ const unsubscribe = (state = {}, chanId) => {
   })
 
   state.pendingUnsubscriptions.push(chanId)
+
+  return state
 }
 
 module.exports = unsubscribe

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-core",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Core Bitfinex Node API",
   "engines": {
     "node": ">=7"
@@ -45,6 +45,7 @@
     "bfx-api-node-models": "^1.0.12",
     "bfx-api-node-rest": "^1.1.3",
     "bfx-api-node-util": "^1.0.2",
-    "bfx-api-node-ws1": "^1.0.0"
+    "bfx-api-node-ws1": "^1.0.0",
+    "utf-8-validate": "^5.0.2"
   }
 }


### PR DESCRIPTION
### Description:
Returns state (as expected) from WSv2 `subscribe()` and `unsubscribe()` methods

Closes https://github.com/bitfinexcom/bfx-hf-strategy-exec/issues/8

### Fixes:
- [x] return state from ws2 `subscribe()`
- [x] return state from ws2 `unsubscribe()`

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
