### PR TITLE
Fix: Auth Args 1.1.7

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+# 1.1.7
+- feature: add updateAuthargs() to manager
+- fix: use internal manager args on auth()
+
 # 1.1.6
 - fix: return state from ws2 subscribe()
 - fix: return state from ws2 unsubscribe()

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -2,6 +2,7 @@
 
 const debug = require('debug')('bfx:api:manager')
 const { RESTv2 } = require('bfx-api-node-rest')
+const _isFinite = require('lodash/isFunction')
 const _isFunction = require('lodash/isFunction')
 const _isObject = require('lodash/isObject')
 const _isArray = require('lodash/isArray')
@@ -90,6 +91,13 @@ class Manager extends EventEmitter {
     })
   }
 
+  updateAuthArgs (args = {}) {
+    this.authArgs = {
+      ...this.authArgs,
+      ...args
+    }
+  }
+
   /**
    * @param {Object} plugin
    * @return {boolean} hasPlugin
@@ -121,11 +129,11 @@ class Manager extends EventEmitter {
    * @param {number?} args.dms - dead man switch, active 4
    * @param {number?} args.calc
    */
-  auth ({ apiKey, apiSecret, dms = 0, calc = 0 } = {}) {
+  auth ({ apiKey, apiSecret, dms, calc } = {}) {
     if (_isString(apiKey)) this.apiKey = apiKey
     if (_isString(apiSecret)) this.apiSecret = apiSecret
-
-    this.authArgs = { dms, calc }
+    if (_isFinite(calc)) this.authArgs.calc = calc
+    if (_isFinite(dms)) this.authArgs.dms = dms
 
     for (let i = 0; i < this.wsPool.length; i += 1) {
       const ws = this.wsPool[i]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-core",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Core Bitfinex Node API",
   "engines": {
     "node": ">=7"


### PR DESCRIPTION
### Description:
Internal auth args were not being used in `auth()` (overridden by default `dms` and `calc` params in the function. Also adds `updateAuthArgs()` to the manager.

### New features:
- [x] added Manager `updateAuthArgs()`

### Fixes:
- [x] Manager now respects internal auth arg settiings

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
