### PR TITLE
Fix: Use relative paths to allow generic mocha execution 1.1.8

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 1.1.8
+- fix: refactor tests so they can run alongside all other HF/API library tests
+
 # 1.1.7
 - feature: add updateAuthargs() to manager
 - fix: use internal manager args on auth()

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 # 1.1.8
-- fix: refactor tests so they can run alongside all other HF/API library tests
+- fix: use relative paths to allow generic mocha execution
 
 # 1.1.7
 - feature: add updateAuthargs() to manager

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-core",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Core Bitfinex Node API",
   "engines": {
     "node": ">=7"

--- a/test/lib/manager/events/ws_close.js
+++ b/test/lib/manager/events/ws_close.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const assert = require('assert')
-const wsClose = require('manager/events/ws_close')
+const wsClose = require('../../../../lib/manager/events/ws_close')
 
 describe('manager:events:ws_close', () => {
   it('emits selected ws id when ws found in wsPool', () => {

--- a/test/lib/ws2/auth.js
+++ b/test/lib/ws2/auth.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const assert = require('assert')
-const auth = require('ws2/auth')
+const auth = require('../../../lib/ws2/auth')
 
 const defaultState = {
   isOpen: true,

--- a/test/lib/ws2/channels/data_count.js
+++ b/test/lib/ws2/channels/data_count.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const assert = require('assert')
-const dataCount = require('ws2/channels/data_count')
+const dataCount = require('../../../../lib/ws2/channels/data_count')
 
 describe('ws2:channels:data_count', () => {
   it('returns the number of subscriptions plus pending subs, minus pending unsubs', () => {

--- a/test/lib/ws2/channels/pending_sub_data_count.js
+++ b/test/lib/ws2/channels/pending_sub_data_count.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const assert = require('assert')
-const pendingSubDataCount = require('ws2/channels/pending_sub_data_count')
+const pendingSubDataCount = require('../../../../lib/ws2/channels/pending_sub_data_count')
 
 describe('ws2:channels:pending_sub_data_count', () => {
   it('returns the number of pending data subscriptions', () => {

--- a/test/lib/ws2/channels/pending_unsub_data_count.js
+++ b/test/lib/ws2/channels/pending_unsub_data_count.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const assert = require('assert')
-const pendingUnsubDataCount = require('ws2/channels/pending_unsub_data_count')
+const pendingUnsubDataCount = require('../../../../lib/ws2/channels/pending_unsub_data_count')
 
 describe('ws2:channels:pending_unsub_data_count', () => {
   it('returns the number of pending data unsubscriptions', () => {

--- a/test/lib/ws2/events/auth.js
+++ b/test/lib/ws2/events/auth.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const assert = require('assert')
-const onAuthEvent = require('ws2/events/auth')
+const onAuthEvent = require('../../../../lib/ws2/events/auth')
 
 const defaultState = {
   channels: {},

--- a/test/lib/ws2/events/config.js
+++ b/test/lib/ws2/events/config.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const assert = require('assert')
-const onConfigEvent = require('ws2/events/config')
+const onConfigEvent = require('../../../../lib/ws2/events/config')
 
 const defaultState = {
   emit: () => {}

--- a/test/lib/ws2/events/error.js
+++ b/test/lib/ws2/events/error.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const assert = require('assert')
-const onErrorEvent = require('ws2/events/error')
+const onErrorEvent = require('../../../../lib/ws2/events/error')
 
 const defaultState = {
   emit: () => {}

--- a/test/lib/ws2/events/info.js
+++ b/test/lib/ws2/events/info.js
@@ -2,8 +2,8 @@
 'use strict'
 
 const assert = require('assert')
-const onInfoEvent = require('ws2/events/info')
-const Config = require('config')
+const onInfoEvent = require('../../../../lib/ws2/events/info')
+const Config = require('../../../../lib/config')
 
 const defaultState = {
   emit: () => {},

--- a/test/lib/ws2/events/subscribed.js
+++ b/test/lib/ws2/events/subscribed.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const assert = require('assert')
-const onSubscribedEvent = require('ws2/events/subscribed')
+const onSubscribedEvent = require('../../../../lib/ws2/events/subscribed')
 
 const defaultState = {
   pendingSubscriptions: [],

--- a/test/lib/ws2/events/unsubscribed.js
+++ b/test/lib/ws2/events/unsubscribed.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const assert = require('assert')
-const onUnsubscribedEvent = require('ws2/events/unsubscribed')
+const onUnsubscribedEvent = require('../../../../lib/ws2/events/unsubscribed')
 
 const defaultState = {
   pendingUnsubscriptions: [],

--- a/test/lib/ws2/flags/disable.js
+++ b/test/lib/ws2/flags/disable.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const assert = require('assert')
-const disableFlag = require('ws2/flags/disable')
+const disableFlag = require('../../../../lib/ws2/flags/disable')
 
 const defaultState = {
   flags: 0,

--- a/test/lib/ws2/flags/enable.js
+++ b/test/lib/ws2/flags/enable.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const assert = require('assert')
-const enableFlag = require('ws2/flags/enable')
+const enableFlag = require('../../../../lib/ws2/flags/enable')
 
 const defaultState = {
   flags: 0,

--- a/test/lib/ws2/flags/is_enabled.js
+++ b/test/lib/ws2/flags/is_enabled.js
@@ -2,8 +2,8 @@
 'use strict'
 
 const assert = require('assert')
-const isFlagEnabled = require('ws2/flags/is_enabled')
-const Config = require('config')
+const isFlagEnabled = require('../../../../lib/ws2/flags/is_enabled')
+const Config = require('../../../../lib/config')
 
 const state = {
   flags: Config.FLAGS.SEQ_ALL + Config.FLAGS.OB_CHECKSUM

--- a/test/lib/ws2/flags/set.js
+++ b/test/lib/ws2/flags/set.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const assert = require('assert')
-const setFlag = require('ws2/flags/set')
+const setFlag = require('../../../../lib/ws2/flags/set')
 
 const defaultState = {
   isOpen: true,

--- a/test/lib/ws2/messages/auth.js
+++ b/test/lib/ws2/messages/auth.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const assert = require('assert')
-const onAuthMessage = require('ws2/messages/auth')
+const onAuthMessage = require('../../../../lib/ws2/messages/auth')
 const { Position } = require('bfx-api-node-models')
 
 const defaultState = {

--- a/test/lib/ws2/messages/books.js
+++ b/test/lib/ws2/messages/books.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const assert = require('assert')
-const onBooksMessage = require('ws2/messages/books')
+const onBooksMessage = require('../../../../lib/ws2/messages/books')
 const { OrderBook } = require('bfx-api-node-models')
 
 const defaultState = {

--- a/test/lib/ws2/messages/candles.js
+++ b/test/lib/ws2/messages/candles.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const assert = require('assert')
-const onCandlesMessage = require('ws2/messages/candles')
+const onCandlesMessage = require('../../../../lib/ws2/messages/candles')
 const _isObject = require('lodash/isObject')
 
 const defaultState = {

--- a/test/lib/ws2/messages/notifications.js
+++ b/test/lib/ws2/messages/notifications.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const assert = require('assert')
-const onNotificationMessage = require('ws2/messages/notifications')
+const onNotificationMessage = require('../../../../lib/ws2/messages/notifications')
 const { Notification } = require('bfx-api-node-models')
 
 const defaultState = {

--- a/test/lib/ws2/messages/tickers.js
+++ b/test/lib/ws2/messages/tickers.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const assert = require('assert')
-const onTickersMessage = require('ws2/messages/tickers')
+const onTickersMessage = require('../../../../lib/ws2/messages/tickers')
 const { TradingTicker, FundingTicker } = require('bfx-api-node-models')
 
 const defaultState = {

--- a/test/lib/ws2/messages/trades.js
+++ b/test/lib/ws2/messages/trades.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const assert = require('assert')
-const onTradesMessage = require('ws2/messages/trades')
+const onTradesMessage = require('../../../../lib/ws2/messages/trades')
 const { Trade, PublicTrade } = require('bfx-api-node-models')
 
 const defaultState = {

--- a/test/lib/ws2/orders/cancel.js
+++ b/test/lib/ws2/orders/cancel.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const assert = require('assert')
-const cancelOrder = require('ws2/orders/cancel')
+const cancelOrder = require('../../../../lib/ws2/orders/cancel')
 const { Order } = require('bfx-api-node-models')
 
 const defaultState = {

--- a/test/lib/ws2/orders/submit.js
+++ b/test/lib/ws2/orders/submit.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const assert = require('assert')
-const submitOrder = require('ws2/orders/submit')
+const submitOrder = require('../../../../lib/ws2/orders/submit')
 const { Order } = require('bfx-api-node-models')
 
 const defaultState = {

--- a/test/lib/ws2/orders/update.js
+++ b/test/lib/ws2/orders/update.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const assert = require('assert')
-const updateOrder = require('ws2/orders/update')
+const updateOrder = require('../../../../lib/ws2/orders/update')
 
 const defaultState = {
   ev: {


### PR DESCRIPTION
### Fixes:
- [x] Use relative paths in tests

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
