### PR TITLE
authenticate sockets using authToken added

### DIFF
--- a/docs/manager_docs.md
+++ b/docs/manager_docs.md
@@ -41,6 +41,7 @@ opening new sockets/closing existing one as needed.
 | args.agent | <code>Object</code> | connection agent |
 | args.apiKey | <code>string</code> | used to authenticate sockets |
 | args.apiSecret | <code>string</code> | used to authenticate sockets |
+| args.authToken | <code>string</code> | used to authenticate sockets; has priority over API key/secret |
 | args.autoResubscribe | <code>boolean</code> | default true |
 | args.channelsPerSocket | <code>number</code> | defaults to 30 |
 | args.dms | <code>number</code> | dead-man-switch flag sent on auth, active 4 |
@@ -81,6 +82,7 @@ Authenticates all open API connections
 | args | <code>Object</code> | optional, defaults to values provided to constructor |
 | args.apiKey | <code>string</code> |  |
 | args.apiSecret | <code>string</code> |  |
+| args.authToken | <code>string</code> |  optional, has priority over API key/secret|
 | args.dms | <code>number</code> | dead man switch, active 4 |
 | args.calc | <code>number</code> |  |
 

--- a/docs/ws2_funcs.md
+++ b/docs/ws2_funcs.md
@@ -87,6 +87,7 @@ Creates & opens a WSv2 API connection, and returns the resulting state object
 | opts.transform | <code>boolean</code> | if true, raw API data arrays will be automatically converted to bfx-api-node-models instances |
 | opts.apiKey | <code>string</code> | for later authentication |
 | opts.apiSecret | <code>string</code> | for later authentication |
+| args.authToken | <code>string</code> |  for later authentication; optional, has priority over API key/secret|
 | opts.plugins | <code>Object</code> | optional set of plugins to use with the connection |
 
 <a name="open"></a>

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -46,6 +46,7 @@ class Manager extends EventEmitter {
    * @param {Object?} args.agent - connection agent
    * @param {string?} args.apiKey - used to authenticate sockets
    * @param {string?} args.apiSecret - used to authenticate sockets
+   * @param {string?} args.authToken - used to authenticate sockets; has priority over API key/secret
    * @param {boolean} args.autoResubscribe - default true
    * @param {number} args.channelsPerSocket - defaults to 30
    * @param {number} args.dms - dead-man-switch flag sent on auth, active 4
@@ -59,6 +60,7 @@ class Manager extends EventEmitter {
     const {
       apiKey,
       apiSecret,
+      authToken,
       channelsPerSocket = 30,
       autoResubscribe = true,
       restURL = REST_URL,
@@ -73,6 +75,7 @@ class Manager extends EventEmitter {
     this._agent = agent
     this.apiKey = apiKey
     this.apiSecret = apiSecret
+    this.authToken = authToken
     this._restURL = restURL
     this._wsURL = wsURL
     this._transform = transform
@@ -85,6 +88,7 @@ class Manager extends EventEmitter {
     this.rest = new RESTv2({
       apiKey,
       apiSecret,
+      authToken,
       transform,
       agent,
       url: restURL
@@ -126,12 +130,14 @@ class Manager extends EventEmitter {
    * @param {Object?} args - optional, defaults to values provided to constructor
    * @param {string?} args.apiKey
    * @param {string?} args.apiSecret
+   * @param {string?} args.authToken
    * @param {number?} args.dms - dead man switch, active 4
    * @param {number?} args.calc
    */
-  auth ({ apiKey, apiSecret, dms, calc } = {}) {
+  auth ({ apiKey, apiSecret, authToken, dms, calc } = {}) {
     if (_isString(apiKey)) this.apiKey = apiKey
     if (_isString(apiSecret)) this.apiSecret = apiSecret
+    if (_isString(authToken)) this.authToken = authToken
     if (_isFinite(calc)) this.authArgs.calc = calc
     if (_isFinite(dms)) this.authArgs.dms = dms
 
@@ -143,7 +149,8 @@ class Manager extends EventEmitter {
         const nextWS = {
           ...ws,
           apiKey: this.apiKey,
-          apiSecret: this.apiSecret
+          apiSecret: this.apiSecret,
+          authToken: this.authToken
         }
 
         authWS(nextWS, this.authArgs)
@@ -252,6 +259,7 @@ class Manager extends EventEmitter {
       agent: this._agent,
       apiKey: this.apiKey,
       apiSecret: this.apiSecret,
+      authToken: this.authToken,
       transform: this._transform,
       plugins: this.plugins
     })

--- a/lib/manager/events/ws_open.js
+++ b/lib/manager/events/ws_open.js
@@ -24,7 +24,7 @@ module.exports = (m, id) => {
   m.notifyPlugins('ws2', 'ws', 'open', { id })
   m.emit('ws2:open', { id })
 
-  if (m.apiKey && m.apiSecret) {
+  if (m.authToken || (m.apiKey && m.apiSecret)) {
     authWS(ws, m.authArgs).then(() => {
       debug('authenticated socket %d', id)
     }).catch((err) => {

--- a/lib/util/get_auth_params.js
+++ b/lib/util/get_auth_params.js
@@ -1,0 +1,40 @@
+'use strict'
+
+const { genAuthSig, nonce } = require('bfx-api-node-util')
+
+const getAuthParams = (state, dms, calc) => {
+  const { apiKey, apiSecret, authToken } = state
+
+  const authParams = {
+    event: 'auth',
+    dms,
+    calc
+  }
+
+  if (authToken) {
+    return {
+      ...authParams,
+      token: authToken
+    }
+  }
+
+  if (apiKey && apiSecret) {
+    const authNonce = nonce()
+    const authPayload = `AUTH${authNonce}${authNonce}`
+    const { sig } = genAuthSig(apiSecret, authPayload)
+
+    return {
+      ...authParams,
+      apiKey,
+      authSig: sig,
+      authPayload,
+      authNonce
+    }
+  }
+
+  return authParams
+}
+
+module.exports = {
+  get: getAuthParams
+}

--- a/lib/ws2/auth.js
+++ b/lib/ws2/auth.js
@@ -2,8 +2,8 @@
 
 const debug = require('debug')('bfx:api:ws2:auth')
 const Promise = require('bluebird')
-const { genAuthSig, nonce } = require('bfx-api-node-util')
 
+const getAuthParams = require('../util/get_auth_params')
 const send = require('./send')
 
 /**
@@ -18,10 +18,9 @@ const send = require('./send')
  * @return {Promise} p - resolves on successful auth
  */
 const auth = (state = {}, { dms = 0, calc = 0 } = {}) => {
-  const { ev, apiKey, apiSecret } = state
-  const authNonce = nonce()
-  const authPayload = `AUTH${authNonce}${authNonce}`
-  const { sig } = genAuthSig(apiSecret, authPayload)
+  const { ev } = state
+
+  const authParams = getAuthParams.get(state, dms, calc)
 
   return new Promise((resolve, reject) => {
     ev.once('event:auth:success', () => {
@@ -34,15 +33,7 @@ const auth = (state = {}, { dms = 0, calc = 0 } = {}) => {
       reject(err)
     })
 
-    send(state, {
-      event: 'auth',
-      apiKey,
-      authSig: sig,
-      authPayload,
-      authNonce,
-      dms,
-      calc
-    })
+    send(state, authParams)
   })
 }
 

--- a/lib/ws2/init_state.js
+++ b/lib/ws2/init_state.js
@@ -16,12 +16,14 @@ const open = require('./open')
  * @param {boolean?} opts.transform - if true, raw API data arrays will be automatically converted to bfx-api-node-models instances
  * @param {string?} opts.apiKey - for later authentication
  * @param {string?} opts.apiSecret - for later authentication
+ * @param {string?} opts.authToken - for later authentication; takes priority over apiKey and apiSecret
  * @param {Object?} opts.plugins - optional set of plugins to use with the connection
  * @return {Object} state
  */
 const initState = (opts = {}) => {
   const {
     agent,
+    authToken,
     apiKey,
     apiSecret,
     plugins = {},
@@ -45,6 +47,7 @@ const initState = (opts = {}) => {
     isOpen: false,
     sendBuffer: [],
 
+    authToken,
     apiKey,
     apiSecret,
     transform,

--- a/test/lib/util/get_auth_params.js
+++ b/test/lib/util/get_auth_params.js
@@ -1,0 +1,44 @@
+/* eslint-env mocha */
+'use strict'
+
+const assert = require('assert')
+
+const getAuthParams = require('../../../lib/util/get_auth_params')
+
+describe('utils:get_auth_params', () => {
+  it('prioritizes authToken over apiKey and apiSecret', () => {
+    const dms = 4
+    const calc = 0
+    const state = {
+      apiKey: 'key',
+      apiSecret: 'secret',
+      authToken: 'token'
+    }
+
+    const res = getAuthParams.get(state, dms, calc)
+
+    assert.deepStrictEqual(res.event, 'auth')
+    assert.deepStrictEqual(res.dms, dms)
+    assert.deepStrictEqual(res.calc, calc)
+    assert.deepStrictEqual(res.token, state.authToken)
+    assert.deepStrictEqual(Object.keys(res), ['event', 'dms', 'calc', 'token'])
+  })
+
+  it('returns params with apiKey and apiSecret when authToken is not provided', () => {
+    const dms = 4
+    const calc = 0
+    const state = {
+      apiKey: 'key',
+      apiSecret: 'secret',
+      authToken: ''
+    }
+
+    const res = getAuthParams.get(state, dms, calc)
+
+    assert.deepStrictEqual(res.event, 'auth')
+    assert.deepStrictEqual(res.dms, dms)
+    assert.deepStrictEqual(res.calc, calc)
+    assert.deepStrictEqual(res.apiKey, state.apiKey)
+    assert.deepStrictEqual(Object.keys(res), ['event', 'dms', 'calc', 'apiKey', 'authSig', 'authPayload', 'authNonce'])
+  })
+})

--- a/test/lib/ws2/auth.js
+++ b/test/lib/ws2/auth.js
@@ -40,6 +40,27 @@ describe('ws2:auth', () => {
     })
   })
 
+  it('sends auth packet w/ authToken', (done) => {
+    auth({
+      ...defaultState,
+      authToken: 'token',
+      ws: {
+        send: (json) => {
+          const msg = JSON.parse(json)
+
+          assert.strictEqual(msg.event, 'auth')
+          assert.strictEqual(msg.token, 'token')
+          assert.strictEqual(msg.dms, 4)
+          assert.strictEqual(msg.calc, 0)
+          done()
+        }
+      }
+    }, {
+      dms: 4,
+      calc: 0
+    })
+  })
+
   it('binds auth success event listener', (done) => {
     auth({
       ...defaultState,


### PR DESCRIPTION
### Description:
- authToken can be used to authenticate web sockets as well

### New features:
- authToken support added
- authToken when provided is prioritized over apiKey and apiSecret for socket authentication
