### PR TITLE
auto-renew auth token

### DIFF
--- a/docs/manager_docs.md
+++ b/docs/manager_docs.md
@@ -16,13 +16,14 @@ opening new sockets/closing existing one as needed.
     * [.getWSByIndex(index)](#Manager+getWSByIndex) ⇒ <code>Object</code>
     * [.updateWS(id, state)](#Manager+updateWS)
     * [.closeAllSockets()](#Manager+closeAllSockets)
+    * [.reconnectAllSockets()](#Manager+reconnectAllSockets)
     * [.closeWS(id)](#Manager+closeWS)
     * [.openWS()](#Manager+openWS) ⇒ <code>Object</code>
     * [.onWS(eventName, filterValue, cb)](#Manager+onWS)
     * [.onceWS(eventName, filterValue, cb)](#Manager+onceWS)
     * [.notifyPlugins(type, section, name, args)](#Manager+notifyPlugins)
     * [.withFreeDataSocket(cb)](#Manager+withFreeDataSocket)
-    * [.withDataSocket(filterCB, cb)](#Manager+withDataSocket)
+    * [.withDataSocket(filterCb, cb)](#Manager+withDataSocket)
     * [.withAuthSocket(cb)](#Manager+withAuthSocket)
     * [.withSocket(cb)](#Manager+withSocket)
     * [.sampleWS()](#Manager+sampleWS) ⇒ <code>Object</code>
@@ -42,6 +43,8 @@ opening new sockets/closing existing one as needed.
 | args.apiKey | <code>string</code> | used to authenticate sockets |
 | args.apiSecret | <code>string</code> | used to authenticate sockets |
 | args.authToken | <code>string</code> | used to authenticate sockets; has priority over API key/secret |
+| args.userId | <code>number</code> | required if you want to enable auto-renewal for auth tokens |
+| args.authTokenExpiresAt | <code>number</code> | used to auto-renew auth tokens, the token will immediately renewed if not provided |
 | args.autoResubscribe | <code>boolean</code> | default true |
 | args.channelsPerSocket | <code>number</code> | defaults to 30 |
 | args.dms | <code>number</code> | dead-man-switch flag sent on auth, active 4 |
@@ -82,9 +85,10 @@ Authenticates all open API connections
 | args | <code>Object</code> | optional, defaults to values provided to constructor |
 | args.apiKey | <code>string</code> |  |
 | args.apiSecret | <code>string</code> |  |
-| args.authToken | <code>string</code> |  optional, has priority over API key/secret|
+| args.authToken | <code>string</code> |  |
 | args.dms | <code>number</code> | dead man switch, active 4 |
 | args.calc | <code>number</code> |  |
+| args.forceAuth | <code>boolean</code> |  |
 
 <a name="Manager+getWS"></a>
 
@@ -141,6 +145,12 @@ if the connection exists.
 Closes all connections in the pool
 
 **Kind**: instance method of [<code>Manager</code>](#Manager)  
+<a name="Manager+reconnectAllSockets"></a>
+
+### manager.reconnectAllSockets()
+Closes and re-opens all connections in the pool
+
+**Kind**: instance method of [<code>Manager</code>](#Manager)  
 <a name="Manager+closeWS"></a>
 
 ### manager.closeWS(id)
@@ -171,7 +181,7 @@ object.
 | --- | --- | --- |
 | eventName | <code>string</code> |  |
 | filterValue | <code>Object</code> | value(s) to check for |
-| cb | <code>Method</code> |  |
+| cb | <code>function</code> |  |
 
 <a name="Manager+onceWS"></a>
 
@@ -185,7 +195,7 @@ object, and only fires once
 | --- | --- | --- |
 | eventName | <code>string</code> |  |
 | filterValue | <code>Object</code> | value(s) to check for |
-| cb | <code>Method</code> |  |
+| cb | <code>function</code> |  |
 
 <a name="Manager+notifyPlugins"></a>
 
@@ -219,7 +229,7 @@ is opened.
 
 <a name="Manager+withDataSocket"></a>
 
-### manager.withDataSocket(filterCB, cb)
+### manager.withDataSocket(filterCb, cb)
 Calls the provided function with a connection instance that is subscribed
 to a channel matching the provided filter callback, which is called with
 each subscribed channel descriptor.
@@ -228,7 +238,7 @@ each subscribed channel descriptor.
 
 | Param | Type |
 | --- | --- |
-| filterCB | <code>function</code> | 
+| filterCb | <code>function</code> | 
 | cb | <code>function</code> | 
 
 <a name="Manager+withAuthSocket"></a>

--- a/docs/ws2_funcs.md
+++ b/docs/ws2_funcs.md
@@ -17,10 +17,10 @@ an event emitter to capture and report API stream events.</p>
 <dd><p>Sends the provided data to the active WebSocket connection, or buffers it if
 the connection is not yet open.</p>
 </dd>
-<dt><a href="#subscribe">subscribe(state, channel, payload)</a></dt>
+<dt><a href="#subscribe">subscribe(state, channel, payload)</a> ⇒ <code>Object</code></dt>
 <dd><p>Subscribes to the specified channel, buffers if the connection is not open.</p>
 </dd>
-<dt><a href="#unsubscribe">unsubscribe(state, chanId)</a></dt>
+<dt><a href="#unsubscribe">unsubscribe(state, chanId)</a> ⇒ <code>Object</code></dt>
 <dd><p>Unsubscribes from the specified channel, buffers if the connection is not
 open.</p>
 </dd>
@@ -87,7 +87,7 @@ Creates & opens a WSv2 API connection, and returns the resulting state object
 | opts.transform | <code>boolean</code> | if true, raw API data arrays will be automatically converted to bfx-api-node-models instances |
 | opts.apiKey | <code>string</code> | for later authentication |
 | opts.apiSecret | <code>string</code> | for later authentication |
-| args.authToken | <code>string</code> |  for later authentication; optional, has priority over API key/secret|
+| opts.authToken | <code>string</code> | for later authentication; takes priority over apiKey and apiSecret |
 | opts.plugins | <code>Object</code> | optional set of plugins to use with the connection |
 
 <a name="open"></a>
@@ -119,10 +119,11 @@ the connection is not yet open.
 
 <a name="subscribe"></a>
 
-## subscribe(state, channel, payload)
+## subscribe(state, channel, payload) ⇒ <code>Object</code>
 Subscribes to the specified channel, buffers if the connection is not open.
 
 **Kind**: global function  
+**Returns**: <code>Object</code> - state - original ref  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -132,11 +133,12 @@ Subscribes to the specified channel, buffers if the connection is not open.
 
 <a name="unsubscribe"></a>
 
-## unsubscribe(state, chanId)
+## unsubscribe(state, chanId) ⇒ <code>Object</code>
 Unsubscribes from the specified channel, buffers if the connection is not
 open.
 
 **Kind**: global function  
+**Returns**: <code>Object</code> - state - original ref  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/lib/config.js
+++ b/lib/config.js
@@ -3,6 +3,7 @@
 module.exports = {
   REST_URL: 'https://api.bitfinex.com',
   WS_URL: 'wss://api.bitfinex.com/ws/2',
+  AUTH_URL: 'http://localhost:5050',
   DUST: 0.0000001,
 
   INFO_CODES: {

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -20,6 +20,7 @@ const initWSState = require('./ws2/init_state')
 const authWS = require('./ws2/auth')
 const reopenWS = require('./ws2/reopen')
 
+const { renewAuthToken } = require('./manager/auth')
 const onWSReopen = require('./manager/events/ws_reopen')
 const onWSOpen = require('./manager/events/ws_open')
 const onWSClose = require('./manager/events/ws_close')
@@ -48,6 +49,8 @@ class Manager extends EventEmitter {
    * @param {string?} args.apiKey - used to authenticate sockets
    * @param {string?} args.apiSecret - used to authenticate sockets
    * @param {string?} args.authToken - used to authenticate sockets; has priority over API key/secret
+   * @param {number?} args.userId - required if you want to enable auto-renewal for auth tokens
+   * @param {number?} args.authTokenExpiresAt - used to auto-renew auth tokens, the token will immediately renewed if not provided
    * @param {boolean} args.autoResubscribe - default true
    * @param {number} args.channelsPerSocket - defaults to 30
    * @param {number} args.dms - dead-man-switch flag sent on auth, active 4
@@ -57,15 +60,19 @@ class Manager extends EventEmitter {
    */
   constructor (args = {}) {
     super()
+    this._renewAuthToken = this._renewAuthToken.bind(this)
 
     const {
       apiKey,
       apiSecret,
       authToken,
+      userId,
+      authTokenExpiresAt,
       channelsPerSocket = 30,
       autoResubscribe = true,
       restURL = REST_URL,
       wsURL = WS_URL,
+      authURL,
       dms = 0,
       calc = 0,
       plugins = [],
@@ -77,8 +84,11 @@ class Manager extends EventEmitter {
     this.apiKey = apiKey
     this.apiSecret = apiSecret
     this.authToken = authToken
+    this.userId = userId
+    this.authTokenExpiresAt = authTokenExpiresAt
     this._restURL = restURL
     this._wsURL = wsURL
+    this._authURL = authURL
     this._transform = transform
     this._channelsPerSocket = channelsPerSocket
     this.autoResubscribe = autoResubscribe
@@ -86,14 +96,53 @@ class Manager extends EventEmitter {
     this.wsPool = []
     this.authArgs = { dms, calc }
 
+    if (this.authToken && this.userId) {
+      this._scheduleAutoRenewal()
+    }
+
+    this._createRestClient()
+  }
+
+  _createRestClient () {
     this.rest = new RESTv2({
-      apiKey,
-      apiSecret,
-      authToken,
-      transform,
-      agent,
-      url: restURL
+      apiKey: this.apiKey,
+      apiSecret: this.apiSecret,
+      authToken: this.authToken,
+      transform: this._transform,
+      agent: this._agent,
+      url: this._restURL
     })
+  }
+
+  _scheduleAutoRenewal () {
+    const threshold = 60 * 60 * 1000 // one hour
+    const timeout = this.authTokenExpiresAt ? ((this.authTokenExpiresAt * 1000) - Date.now() - threshold) : 0
+    setTimeout(this._renewAuthToken, timeout)
+  }
+
+  async _renewAuthToken () {
+    try {
+      const { token, expiresAt } = await renewAuthToken({
+        authURL: this._authURL,
+        userId: this.userId,
+        authToken: this.authToken
+      })
+
+      this.authToken = token
+      this.authTokenExpiresAt = expiresAt
+
+      this.auth({
+        ...this.authArgs,
+        apiKey: this.apiKey,
+        apiSecret: this.apiSecret,
+        authToken: token,
+        forceAuth: true
+      })
+      this._createRestClient()
+      this._scheduleAutoRenewal()
+    } catch (e) {
+      debug('failed to renew auth token: %j', e)
+    }
   }
 
   updateAuthArgs (args = {}) {
@@ -134,8 +183,9 @@ class Manager extends EventEmitter {
    * @param {string?} args.authToken
    * @param {number?} args.dms - dead man switch, active 4
    * @param {number?} args.calc
+   * @param {boolean?} args.forceAuth
    */
-  auth ({ apiKey, apiSecret, authToken, dms, calc } = {}) {
+  auth ({ apiKey, apiSecret, authToken, dms, calc, forceAuth } = {}) {
     if (_isString(apiKey)) this.apiKey = apiKey
     if (_isString(apiSecret)) this.apiSecret = apiSecret
     if (_isString(authToken)) this.authToken = authToken
@@ -146,7 +196,7 @@ class Manager extends EventEmitter {
       const ws = this.wsPool[i]
       const { authenticated } = ws
 
-      if (!authenticated) {
+      if (!authenticated || forceAuth) {
         const nextWS = {
           ...ws,
           apiKey: this.apiKey,

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -98,6 +98,7 @@ class Manager extends EventEmitter {
 
     if (this.authToken && this.userId) {
       this._scheduleAutoRenewal()
+      this.on('auth:token:updated', this._onAuthTokenUpdated)
     }
 
     this._createRestClient()
@@ -133,18 +134,24 @@ class Manager extends EventEmitter {
       this.authToken = token
       this.authTokenExpiresAt = expiresAt
 
-      this.auth({
-        ...this.authArgs,
-        apiKey: this.apiKey,
-        apiSecret: this.apiSecret,
-        authToken: token,
-        forceAuth: true
-      })
-      this._createRestClient()
+      this.emit('auth:token:updated', { authToken: token })
+
       this._scheduleAutoRenewal()
     } catch (e) {
       debug('failed to renew auth token: %j', e)
     }
+  }
+
+  _onAuthTokenUpdated ({ authToken }) {
+    this.auth({
+      ...this.authArgs,
+      apiKey: this.apiKey,
+      apiSecret: this.apiSecret,
+      authToken: authToken,
+      forceAuth: true
+    })
+
+    this._createRestClient()
   }
 
   updateAuthArgs (args = {}) {

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -156,8 +156,8 @@ class Manager extends EventEmitter {
    * @param {Object} plugin
    * @return {boolean} hasPlugin
    */
-  hasPlugin (p = {}) {
-    return !!this.plugins[p.id]
+  hasPlugin (plugin = {}) {
+    return !!this.plugins[plugin.id]
   }
 
   /**
@@ -165,13 +165,13 @@ class Manager extends EventEmitter {
    *
    * @param {Object} plugin
    */
-  addPlugin (p = {}) {
-    if (this.plugins[p.id]) {
-      debug('plugin %s already registered', p.id)
+  addPlugin (plugin = {}) {
+    if (this.plugins[plugin.id]) {
+      debug('plugin %s already registered', plugin.id)
       return
     }
 
-    this.plugins[p.id] = p
+    this.plugins[plugin.id] = plugin
   }
 
   /**
@@ -372,7 +372,7 @@ class Manager extends EventEmitter {
    *
    * @param {string} eventName
    * @param {Object} filterValue - value(s) to check for
-   * @param {Method} cb
+   * @param {Function} cb
    */
   onWS (eventName, filterValue, cb) {
     this._onWS('on', eventName, filterValue, cb)
@@ -384,7 +384,7 @@ class Manager extends EventEmitter {
    *
    * @param {string} eventName
    * @param {Object} filterValue - value(s) to check for
-   * @param {Method} cb
+   * @param {Function} cb
    */
   onceWS (eventName, filterValue, cb) {
     this._onWS('once', eventName, filterValue, cb)
@@ -398,7 +398,7 @@ class Manager extends EventEmitter {
    * @param {string} bindType - on or once
    * @param {string} eventName
    * @param {Object} filterValue - value(s) to check for
-   * @param {Method} cb
+   * @param {Function} cb
    */
   _onWS (bindType, eventName, filterValue, cb) {
     this[bindType](`ws2:${eventName}`, (...eArgs) => {
@@ -527,7 +527,7 @@ class Manager extends EventEmitter {
    * to a channel matching the provided filter callback, which is called with
    * each subscribed channel descriptor.
    *
-   * @param {Function} filterCB
+   * @param {Function} filterCb
    * @param {Function} cb
    */
   withDataSocket (filterCb, cb) {
@@ -603,12 +603,12 @@ class Manager extends EventEmitter {
    * @param {number} index
    * @param {Function} cb
    */
-  applyWS (i, cb) {
-    const nextState = cb(this.wsPool[i])
+  applyWS (index, cb) {
+    const nextState = cb(this.wsPool[index])
 
     if (_isObject(nextState)) {
-      this.wsPool[i] = nextState
-      this.emit('socket:updated', i, nextState)
+      this.wsPool[index] = nextState
+      this.emit('socket:updated', index, nextState)
     }
   }
 }

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -115,7 +115,7 @@ class Manager extends EventEmitter {
   }
 
   _scheduleAutoRenewal () {
-    const threshold = 60 * 60 * 1000 // one hour
+    const threshold = 60 * 60 * 1000 // renew one hour before expiring
     const timeout = this.authTokenExpiresAt ? ((Number(this.authTokenExpiresAt) * 1000) - Date.now() - threshold) : 0
     this._renewTimeout = setTimeout(this._renewAuthToken, timeout)
   }

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -117,10 +117,12 @@ class Manager extends EventEmitter {
   _scheduleAutoRenewal () {
     const threshold = 60 * 60 * 1000 // one hour
     const timeout = this.authTokenExpiresAt ? ((Number(this.authTokenExpiresAt) * 1000) - Date.now() - threshold) : 0
-    setTimeout(this._renewAuthToken, timeout)
+    this._renewTimeout = setTimeout(this._renewAuthToken, timeout)
   }
 
   async _renewAuthToken () {
+    this._renewTimeout = undefined
+
     try {
       const { token, expiresAt } = await renewAuthToken({
         authURL: this._authURL,

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -116,7 +116,7 @@ class Manager extends EventEmitter {
 
   _scheduleAutoRenewal () {
     const threshold = 60 * 60 * 1000 // one hour
-    const timeout = this.authTokenExpiresAt ? ((this.authTokenExpiresAt * 1000) - Date.now() - threshold) : 0
+    const timeout = this.authTokenExpiresAt ? ((Number(this.authTokenExpiresAt) * 1000) - Date.now() - threshold) : 0
     setTimeout(this._renewAuthToken, timeout)
   }
 

--- a/lib/manager/auth.js
+++ b/lib/manager/auth.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const fetch = require('node-fetch')
+
+const { AUTH_URL } = require('../config')
+
+/**
+ * TODO
+ *
+ * @param {Object} args
+ * @param {string?} args.authURL
+ * @param {string} args.userId
+ * @param {string} args.authToken
+ * @returns {Promise<*>}
+ */
+const renewAuthToken = async ({ authURL, userId, authToken } = {}) => {
+  const baseUrl = authURL || AUTH_URL
+  const url = `${baseUrl}/v1/user/auth`
+  const options = {
+    method: 'POST',
+    body: JSON.stringify({
+      userId: userId,
+      token: authToken
+    })
+  }
+  const request = await fetch(url, options)
+  const { data } = await request.json()
+  return data
+}
+
+module.exports = {
+  renewAuthToken
+}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "chai": "^4.2.0",
     "jsdoc-to-markdown": "^5.0.1",
     "mocha": "^6.2.0",
+    "proxyquire": "^2.1.3",
+    "sinon": "^10.0.0",
     "standard": "^14.1.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "bfx-api-node-rest": "^1.1.3",
     "bfx-api-node-util": "^1.0.2",
     "bfx-api-node-ws1": "^1.0.0",
+    "node-fetch": "^2.6.1",
     "utf-8-validate": "^5.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,10 @@
     "bfx-api-node-rest": "^1.1.3",
     "bfx-api-node-util": "^1.0.2",
     "bfx-api-node-ws1": "^1.0.0",
+    "debug": "^4.3.1",
+    "lodash": "^4.17.21",
     "node-fetch": "^2.6.1",
-    "utf-8-validate": "^5.0.2"
+    "utf-8-validate": "^5.0.2",
+    "ws": "^7.4.5"
   }
 }

--- a/test/lib/manager.js
+++ b/test/lib/manager.js
@@ -1,0 +1,83 @@
+/* eslint-env mocha */
+'use strict'
+
+const { expect } = require('chai')
+const { createSandbox, assert } = require('sinon')
+const proxyquire = require('proxyquire')
+
+const { delay } = require('../utils')
+
+const sandbox = createSandbox()
+const renewAuthTokenStub = sandbox.stub()
+const RESTv2ConstructorStub = sandbox.stub()
+
+const Manager = proxyquire('../../lib/manager', {
+  './manager/auth': {
+    renewAuthToken: renewAuthTokenStub
+  },
+  'bfx-api-node-rest': {
+    RESTv2: sandbox.spy((opts) => {
+      RESTv2ConstructorStub(opts)
+      return {}
+    })
+  }
+})
+
+describe('manager', () => {
+  after(() => {
+    sandbox.restore()
+  })
+
+  describe('auto-renew auth token', () => {
+    const args = {
+      apiKey: 'api key',
+      apiSecret: 'api secret',
+      authToken: 'auth token',
+      userId: 'user id',
+      authTokenExpiresAt: '100',
+      authURL: 'auth url',
+      transform: 'transform',
+      agent: 'agent',
+      restURL: 'rest url'
+    }
+
+    it('immediately renew token if expiresAt is not provided', async () => {
+      const newToken = {
+        token: 'new token',
+        expiresAt: 100
+      }
+      sandbox.stub(Date, 'now').returns(0)
+      renewAuthTokenStub.resolves(newToken)
+
+      const instance = new Manager({
+        ...args,
+        authTokenExpiresAt: undefined
+      })
+      await delay(100)
+
+      assert.calledWithExactly(renewAuthTokenStub, {
+        authURL: args.authURL,
+        userId: args.userId,
+        authToken: args.authToken
+      })
+      assert.calledWithExactly(RESTv2ConstructorStub.firstCall, {
+        apiKey: args.apiKey,
+        apiSecret: args.apiSecret,
+        authToken: args.authToken,
+        transform: args.transform,
+        agent: args.agent,
+        url: args.restURL
+      })
+      assert.calledWithExactly(RESTv2ConstructorStub.secondCall, {
+        apiKey: args.apiKey,
+        apiSecret: args.apiSecret,
+        authToken: newToken.token,
+        transform: args.transform,
+        agent: args.agent,
+        url: args.restURL
+      })
+      expect(instance.authToken).to.eq(newToken.token)
+      expect(instance.authTokenExpiresAt).to.eq(newToken.expiresAt)
+    })
+  })
+})

--- a/test/lib/manager.js
+++ b/test/lib/manager.js
@@ -78,6 +78,9 @@ describe('manager', () => {
       })
       expect(instance.authToken).to.eq(newToken.token)
       expect(instance.authTokenExpiresAt).to.eq(newToken.expiresAt)
+      // eslint-disable-next-line no-unused-expressions
+      expect(instance._renewTimeout).not.to.be.undefined
+      clearTimeout(instance._renewTimeout)
     })
   })
 })

--- a/test/lib/manager/auth.js
+++ b/test/lib/manager/auth.js
@@ -1,0 +1,49 @@
+/* eslint-env mocha */
+'use strict'
+
+const proxyquire = require('proxyquire')
+const { assert, createSandbox } = require('sinon')
+const { expect } = require('chai')
+
+const sandbox = createSandbox()
+const stubFetch = sandbox.stub()
+
+const auth = proxyquire('../../../lib/manager/auth', {
+  'node-fetch': stubFetch
+})
+
+describe('manager auth', () => {
+  after(() => {
+    sandbox.restore()
+  })
+
+  describe('renewAuthToken', () => {
+    const authURL = 'auth url'
+    const userId = 'user id'
+    const authToken = 'old token'
+    const fakeResponse = {
+      message: 'User auth token created successfully.',
+      data: {
+        userId: 'user id',
+        token: 'new token',
+        renewedAt: 1619611815,
+        expiresAt: 1619698215
+      }
+    }
+
+    it('should renew auth token via auth api', async () => {
+      const stubJson = sandbox.stub().resolves(fakeResponse)
+      stubFetch.resolves({ json: stubJson })
+
+      const data = await auth.renewAuthToken({ authURL, userId, authToken })
+
+      assert.calledWithExactly(
+        stubFetch,
+        'auth url/v1/user/auth',
+        { method: 'POST', body: '{"userId":"user id","token":"old token"}' }
+      )
+      assert.calledOnce(stubJson)
+      expect(data).to.eql(fakeResponse.data)
+    })
+  })
+})

--- a/test/utils/delay.js
+++ b/test/utils/delay.js
@@ -1,0 +1,5 @@
+module.exports.delay = (ms) => {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = {
+  ...require('./delay')
+}


### PR DESCRIPTION
### Description:
The core lib supports auth tokens as an alternative for API keys, but they have a short TTL, to avoid expiring issues we should allow auto-renewing and hot-swap of tokens.

### Breaking changes:
- [ ]

### New features:
- [ X] Auto-renew of tokens 

### Fixes:
- [ ]

### PR status:
- [ ] Version bumped
- [ ] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
