### PR TITLE
Add cancel order by gid

### DIFF
--- a/examples/cancel_order_by_gid.js
+++ b/examples/cancel_order_by_gid.js
@@ -1,0 +1,27 @@
+'use strict'
+
+process.env.DEBUG = '*'
+
+const debug = require('debug')('bfx:api:core:examples:cancel_order_by_gid')
+const { Manager, cancelOrdersByGid } = require('../')
+
+debug('opening connection...')
+
+const gid = 1622459132273
+
+const m = new Manager({
+  apiKey: 'api key',
+  apiSecret: 'api secret',
+  transform: true
+})
+
+const wsState = m.openWS()
+
+m.on('ws2:open', () => debug('connection opened'))
+m.on('ws2:close', () => debug('connection closed'))
+
+m.on('ws2:event:auth:success', (packet) => {
+  cancelOrdersByGid(wsState, { gid })
+    .then(console.log)
+    .catch(console.error)
+})

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -31,6 +31,7 @@ const onPluginEvent = require('./manager/events/plugin')
 const onOrderSubmitEvent = require('./manager/events/order_submit')
 const onOrderUpdateEvent = require('./manager/events/order_update')
 const onOrderCancelEvent = require('./manager/events/order_cancel')
+const onOrderCancelByGidEvent = require('./manager/events/order_cancel_by_gid')
 const onPingEvent = require('./manager/events/ping')
 const onSetFlags = require('./manager/events/set_flags')
 
@@ -294,6 +295,7 @@ class Manager extends EventEmitter {
     ev.on('exec:order:submit', onOrderSubmitEvent.bind(this, this, id))
     ev.on('exec:order:update', onOrderUpdateEvent.bind(this, this, id))
     ev.on('exec:order:cancel', onOrderCancelEvent.bind(this, this, id))
+    ev.on('exec:order:cancel-by-gid', onOrderCancelByGidEvent.bind(this, this, id))
     ev.on('exec:flags:set', onSetFlags.bind(this, this, { id }))
     ev.on('exec:ping', onPingEvent.bind(this, this, id))
 

--- a/lib/manager/events/order_cancel_by_gid.js
+++ b/lib/manager/events/order_cancel_by_gid.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const sendWS = require('../../ws2/send')
+
+/**
+ * Cancel multiple orders using Group ID
+ *
+ * @param {Manager} m
+ * @param {number} wsID - socket ID
+ * @param {number} gid - order GID to cancel
+ */
+module.exports = (m, wsID, gid) => {
+  const ws = m.getWS(wsID)
+
+  sendWS(ws, [0, 'oc_multi', null, { gid: [+gid] }])
+}

--- a/lib/ws2/index.js
+++ b/lib/ws2/index.js
@@ -19,6 +19,7 @@ module.exports = {
   updateOrder: require('./orders/update'),
   cancelOrder: require('./orders/cancel'),
   cancelOrderWithDelay: require('./orders/cancel_with_delay'),
+  cancelOrdersByGid: require('./orders/cancel_by_gid'),
 
   setFlag: require('./flags/set'),
   enableFlag: require('./flags/enable'),

--- a/lib/ws2/messages/notifications.js
+++ b/lib/ws2/messages/notifications.js
@@ -5,10 +5,13 @@ const getMsgPayload = require('../../util/msg_payload')
 const { Notification } = require('bfx-api-node-models')
 const _isFinite = require('lodash/isFinite')
 
+const CANCEL_MULTI_ORDER_TYPE = 'oc_multi-req'
+
 const idIndex = {
   'on-req': 2,
   'ou-req': 0,
-  'oc-req': 0
+  'oc-req': 0,
+  [CANCEL_MULTI_ORDER_TYPE]: 1
 }
 
 module.exports = (args = {}) => {
@@ -30,7 +33,9 @@ module.exports = (args = {}) => {
   })
 
   if (payload && _isFinite(idIndex[type])) {
-    const eid = payload[idIndex[type]]
+    const payloadForEid = type === CANCEL_MULTI_ORDER_TYPE && payload[0] ? payload[0] : payload
+
+    const eid = payloadForEid[idIndex[type]]
     const nData = transform
       ? new Notification(data)
       : payload

--- a/lib/ws2/orders/cancel_by_gid.js
+++ b/lib/ws2/orders/cancel_by_gid.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const Promise = require('bluebird')
 const debug = require('debug')('bfx:api:ws2:orders:cancel_by_gid')
+const watchResponse = require('../../util/watch_response')
 
 const cancelOrderByGid = (state = {}, opts) => {
   const { ev, emit } = state
@@ -11,13 +11,7 @@ const cancelOrderByGid = (state = {}, opts) => {
 
   emit('exec:order:cancel-by-gid', gid)
 
-  return new Promise((resolve, reject) => {
-    ev.once(`n:oc_multi-req:${gid}:success`, (notification, oc) => {
-      resolve(notification, oc)
-    })
-
-    ev.once(`n:oc_multi-req:${gid}:error`, reject)
-  })
+  return watchResponse(ev, `n:oc_multi-req:${gid}:success`, `n:oc_multi-req:${gid}:error`)
 }
 
 module.exports = cancelOrderByGid

--- a/lib/ws2/orders/cancel_by_gid.js
+++ b/lib/ws2/orders/cancel_by_gid.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const Promise = require('bluebird')
+const debug = require('debug')('bfx:api:ws2:orders:cancel_by_gid')
+
+const cancelOrderByGid = (state = {}, opts) => {
+  const { ev, emit } = state
+  const { gid } = opts
+
+  debug('canceling order by gid: %s', gid)
+
+  emit('exec:order:cancel-by-gid', gid)
+
+  return new Promise((resolve, reject) => {
+    ev.once(`n:oc_multi-req:${gid}:success`, (notification, oc) => {
+      resolve(notification, oc)
+    })
+
+    ev.once(`n:oc_multi-req:${gid}:error`, reject)
+  })
+}
+
+module.exports = cancelOrderByGid

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "mocha": "^6.2.0",
     "proxyquire": "^2.1.3",
     "sinon": "^10.0.0",
-    "standard": "^14.1.0"
+    "standard": "^16.0.3"
   },
   "dependencies": {
     "bfx-api-node-models": "^1.0.12",

--- a/test/lib/manager.js
+++ b/test/lib/manager.js
@@ -91,6 +91,7 @@ describe('manager', () => {
         'exec:order:submit',
         'exec:order:update',
         'exec:order:cancel',
+        'exec:order:cancel-by-gid',
         'exec:flags:set',
         'exec:ping'
       ])

--- a/test/lib/ws2/orders/cancel_by_gid.js
+++ b/test/lib/ws2/orders/cancel_by_gid.js
@@ -6,7 +6,8 @@ const cancelOrderByGid = require('../../../../lib/ws2/orders/cancel_by_gid')
 
 const defaultState = {
   ev: {
-    once: () => {}
+    off: () => {},
+    once: (_, handler) => { handler() }
   },
   emit: () => {},
   transform: false
@@ -31,8 +32,10 @@ describe('ws2:orders:cancel_by_gid', () => {
     cancelOrderByGid({
       ...defaultState,
       ev: {
+        off: () => {},
         once: (eventName, handler) => {
           if (eventName === `n:oc_multi-req:${gid}:success`) {
+            handler()
             assert(handler)
             done()
           }
@@ -45,10 +48,13 @@ describe('ws2:orders:cancel_by_gid', () => {
     cancelOrderByGid({
       ...defaultState,
       ev: {
+        off: () => {},
         once: (eventName, handler) => {
           if (eventName === `n:oc_multi-req:${gid}:error`) {
             assert(handler)
             done()
+          } else {
+            handler()
           }
         }
       }

--- a/test/lib/ws2/orders/cancel_by_gid.js
+++ b/test/lib/ws2/orders/cancel_by_gid.js
@@ -1,0 +1,57 @@
+/* eslint-env mocha */
+'use strict'
+
+const assert = require('assert')
+const cancelOrderByGid = require('../../../../lib/ws2/orders/cancel_by_gid')
+
+const defaultState = {
+  ev: {
+    once: () => {}
+  },
+  emit: () => {},
+  transform: false
+}
+
+const gid = 1234
+
+describe('ws2:orders:cancel_by_gid', () => {
+  it('emits order cancel event with order GID', (done) => {
+    cancelOrderByGid({
+      ...defaultState,
+      emit: (eventName, packet) => {
+        if (eventName === 'exec:order:cancel-by-gid') {
+          assert.deepStrictEqual(packet, gid)
+          done()
+        }
+      }
+    }, { gid })
+  })
+
+  it('returns a promise that resolves on a matching oc_multi-req notification', (done) => {
+    cancelOrderByGid({
+      ...defaultState,
+      ev: {
+        once: (eventName, handler) => {
+          if (eventName === `n:oc_multi-req:${gid}:success`) {
+            assert(handler)
+            done()
+          }
+        }
+      }
+    }, { gid })
+  })
+
+  it('returns a promise that rejects on a matching oc_multi-req error notification', (done) => {
+    cancelOrderByGid({
+      ...defaultState,
+      ev: {
+        once: (eventName, handler) => {
+          if (eventName === `n:oc_multi-req:${gid}:error`) {
+            assert(handler)
+            done()
+          }
+        }
+      }
+    }, { gid })
+  })
+})


### PR DESCRIPTION
### Description:
Uses the 'oc_multi' event for cancelling multiple orders using group id

### New features:
- Added feature to cancel all orders using group id

### Fixes:
- Missing package "chai" added
