### PR TITLE
reset channels and state on reopen event

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -248,7 +248,8 @@ class Manager extends EventEmitter {
       agent: this._agent,
       transform: this._transform,
       plugins: this.plugins,
-      authArgs: this.authArgs
+      authArgs: this.authArgs,
+      autoResubscribe: this.autoResubscribe
     })
 
     this.wsPool.push(wsState)

--- a/lib/manager/events/ws_reopen.js
+++ b/lib/manager/events/ws_reopen.js
@@ -15,13 +15,13 @@ module.exports = (m, id) => {
   }
 
   const wsState = m.getWS(id)
-  const { channels } = wsState
-  const channelIds = Object.keys(channels)
+  const { resubChannels } = wsState
+  const channelIds = Object.keys(resubChannels)
 
   m.emit('ws2:reopen', { id })
 
   channelIds.forEach(chanId => {
-    const data = channels[chanId]
+    const data = resubChannels[chanId]
 
     switch (data.channel) {
       case 'auth': {

--- a/lib/ws2/init_state.js
+++ b/lib/ws2/init_state.js
@@ -27,7 +27,8 @@ const initState = (opts = {}) => {
     authArgs = {},
     plugins = {},
     transform,
-    url = WS_URL
+    url = WS_URL,
+    autoResubscribe = true
   } = opts
 
   const { ev, ws } = open(url, agent)
@@ -48,6 +49,7 @@ const initState = (opts = {}) => {
 
     authArgs,
     transform,
+    autoResubscribe,
     agent,
     emit,
     url,

--- a/lib/ws2/reopen.js
+++ b/lib/ws2/reopen.js
@@ -5,7 +5,7 @@ const open = require('./open')
 const bindEV = require('./bind_ev')
 
 module.exports = (state = {}) => {
-  const { url, agent, ws: oldWS } = state
+  const { url, agent, ws: oldWS, channels, autoResubscribe } = state
 
   if (oldWS && oldWS.readyState === WebSocket.OPEN) {
     oldWS.close()
@@ -21,6 +21,10 @@ module.exports = (state = {}) => {
 
   return {
     ...state,
-    ws
+    channels: {},
+    isOpen: false,
+    authenticated: false,
+    ws,
+    ...(autoResubscribe && { resubChannels: channels })
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-core",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "Core Bitfinex Node API",
   "engines": {
     "node": ">=7"


### PR DESCRIPTION
### Description:
Reset the state on ws reopen and resubscribe previous channels on reconnect

Task: https://app.asana.com/0/1125859137800433/1201133898422707

### Fixes:
- [x] Receive data from previously subscribed channels on reconnect 

### PR status:
- [x] Version bumped
- [ ] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
