### PR TITLE
remove debug entry

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -403,7 +403,6 @@ class Manager extends EventEmitter {
       : []
 
     if (!_isFunction(func)) {
-      debug('plugin %s is missing a handler for type %s', id, type)
       return
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-core",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "Core Bitfinex Node API",
   "engines": {
     "node": ">=7"


### PR DESCRIPTION
Handling all events is not mandatory for plugins, so this debug entry may confuse and flood the logs