### PR TITLE
add support to channel filters 

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -53,6 +53,7 @@ class Manager extends EventEmitter {
    * @param {number} args.calc
    * @param {boolean?} args.transform - if true, raw API data arrays will be automatically converted to bfx-api-node-models instances
    * @param {Object?} args.plugins - optional set of plugins to use
+   * @param {string[]?} args.channelFilters - During authentication you can provide an array to indicate which information/messages you are interested to receive (default = everything).
    */
   constructor (args = {}) {
     super()
@@ -68,7 +69,8 @@ class Manager extends EventEmitter {
       calc = 0,
       plugins = [],
       transform,
-      agent
+      agent,
+      channelFilters
     } = args
 
     this._agent = agent
@@ -78,7 +80,7 @@ class Manager extends EventEmitter {
     this.autoResubscribe = autoResubscribe
     this.plugins = _keyBy(plugins, p => p.id)
     this.wsPool = []
-    this.authArgs = { apiKey, apiSecret, authToken, dms, calc }
+    this.authArgs = { apiKey, apiSecret, authToken, dms, calc, channelFilters }
   }
 
   updateAuthArgs (args = {}) {

--- a/lib/util/get_auth_params.js
+++ b/lib/util/get_auth_params.js
@@ -3,7 +3,7 @@
 const { genAuthSig, nonce } = require('bfx-api-node-util')
 
 const getAuthParams = (authArgs = {}) => {
-  const { apiKey, apiSecret, authToken, dms = 0, calc = 0, filter } = authArgs
+  const { apiKey, apiSecret, authToken, dms = 0, calc = 0, channelFilters } = authArgs
 
   const authParams = {
     event: 'auth',
@@ -11,8 +11,8 @@ const getAuthParams = (authArgs = {}) => {
     calc
   }
 
-  if (Array.isArray(filter)) {
-    authParams.filter = filter
+  if (Array.isArray(channelFilters)) {
+    authParams.filter = channelFilters
   }
 
   if (authToken) {

--- a/lib/util/get_auth_params.js
+++ b/lib/util/get_auth_params.js
@@ -3,12 +3,16 @@
 const { genAuthSig, nonce } = require('bfx-api-node-util')
 
 const getAuthParams = (authArgs = {}) => {
-  const { apiKey, apiSecret, authToken, dms = 0, calc = 0 } = authArgs
+  const { apiKey, apiSecret, authToken, dms = 0, calc = 0, filter } = authArgs
 
   const authParams = {
     event: 'auth',
     dms,
     calc
+  }
+
+  if (Array.isArray(filter)) {
+    authParams.filter = filter
   }
 
   if (authToken) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-api-node-core",
-  "version": "1.5.8",
+  "version": "1.6.0",
   "description": "Core Bitfinex Node API",
   "engines": {
     "node": ">=7"


### PR DESCRIPTION
### Description:
The auth event in API has support for [channel filters](https://docs.bitfinex.com/docs/ws-auth#section-channel-filters), we need to expose this in the lib too.